### PR TITLE
Explicitly set BcdLibraryInteger_DebuggerType to DebuggerSerial.

### DIFF
--- a/vminstall/bootedit.cpp
+++ b/vminstall/bootedit.cpp
@@ -98,6 +98,9 @@ namespace VistaBCD
 				st = m_Object.SetElement(BcdLibraryBoolean_AutoRecoveryEnabled, false);
 				if (!st.Successful())
 					return st;
+				st = m_Object.SetElement(BcdLibraryInteger_DebuggerType, (ULONGLONG)0); //Set DebuggerType to DebuggerSerial
+				if (!st.Successful())
+					return st;
 			}
 
 			return MAKE_STATUS(Success);


### PR DESCRIPTION
Windows 10 14393 (Redstone) has a default Debugger type set to LOCAL and
this breaks the VirtualKD. The workaround is to set Debugger type to
SERIAL for the debug entry, or as default debugger type, I opted for the former.

![win10](https://cloud.githubusercontent.com/assets/5801389/17506537/db9525ba-5e09-11e6-9536-d8dc8143b127.png)

![redstone](https://cloud.githubusercontent.com/assets/5801389/17506543/e750bf90-5e09-11e6-8fff-065bf21e8ade.png)
