### PR TITLE
Update patchapi.cpp

### DIFF
--- a/kdclient/patchapi.cpp
+++ b/kdclient/patchapi.cpp
@@ -154,7 +154,7 @@ unsigned SessionNameFromVMWareCmdLineW(const wchar_t *pszCmdLineConst, wchar_t *
 	size_t todo = end - start;
 	if (todo >= MaxNameLength)
 		todo = MaxNameLength - 1;
-	memcpy(pName, start, todo * sizeof(wchar_t *));
+	memcpy(pName, start, todo * sizeof(wchar_t));
 	pName[todo] = 0;
 	return (unsigned)todo;
 }


### PR DESCRIPTION
A small bug, that leads to out of bound memory access. 
Crashes when I use windbg with gflags.
```windbg
kdclient64!memcpy+0x250:
000007fe`dc2642f0 488b440af8      mov     rax,qword ptr [rdx+rcx-8] ds:00000000`36c19040=????????????????
```
backtrace
```windbg
~kv
dclient64!memcpy+0x250 [f:\dd\vctools\crt_bld\SELF_64_amd64\crt\src\amd64\memcpy.asm @ 344]
00000000`37ddf890 000007fe`dc25b5d6 : 00000000`34ab6cf0 000007fe`dc276e88 00000000`34ab6cf0 00000000`37ddfa70 : kdclient64!SessionNameFromVMWareCmdLineW+0x187 [e:\projects\sysprogs-github\virtualkd\kdclient\patchapi.cpp @ 159]
00000000`37ddf920 000007fe`dc254b91 : 00000000`37ddfa70 00000000`00000001 00000000`00000000 00000000`00000000 : kdclient64!SessionNameFromVMCmdLineW+0x1a6 [e:\projects\sysprogs-github\virtualkd\kdclient\patchapi.cpp @ 180]
00000000`37ddf9c0 00000000`773759cd : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : kdclient64!PatcherThreadMain+0x101 [e:\projects\sysprogs-github\virtualkd\kdclient\kdclient.cpp @ 106]
```

The root cause of the bug is that you accidentally use sizeof(wchat_t *) instead of sizeof(wchat_t )